### PR TITLE
UnitRegistry: Add linker support for unit registry and refactor registration mechanism

### DIFF
--- a/include/OF/lib/applications/Unit/UnitRegistry.hpp
+++ b/include/OF/lib/applications/Unit/UnitRegistry.hpp
@@ -147,7 +147,6 @@ namespace OF
      * @param UnitClass 要注册的Unit派生类名称
      */
 
-#undef REGISTER_UNIT
 #define REGISTER_UNIT(UnitClass) \
     extern "C" { \
         OF::UnitRegistry::UnitFactoryFunction \

--- a/include/OF/lib/applications/Unit/UnitRegistry.hpp
+++ b/include/OF/lib/applications/Unit/UnitRegistry.hpp
@@ -56,16 +56,6 @@ namespace OF
         }
 
         /**
-         * @brief 添加注册函数到注册表
-         *
-         * @details 添加一个在初始化时将被调用的函数，用于注册Unit类型。
-         *          此方法通常由REGISTER_UNIT宏自动调用。
-         *
-         * @param func 指向注册函数的指针
-         */
-        static void addRegistrationFunction(UnitRegistrationFunction func);
-
-        /**
          * @brief 初始化所有注册的单元
          *
          * @details 清理注册表，并调用所有已注册的注册函数，以便注册所有Unit类型。
@@ -156,21 +146,15 @@ namespace OF
      *
      * @param UnitClass 要注册的Unit派生类名称
      */
-#define REGISTER_UNIT(UnitClass)                                                                                       \
-    namespace                                                                                                          \
-    {                                                                                                                  \
-        void OF_CONCAT(registerUnit_, __LINE__)() { OF::UnitRegistry::registerUnit<UnitClass>(); }                     \
-                                                                                                                       \
-        struct OF_CONCAT(UnitRegistrar_, __LINE__)                                                                     \
-        {                                                                                                              \
-            OF_CONCAT(UnitRegistrar_, __LINE__)()                                                                      \
-            {                                                                                                          \
-                OF::UnitRegistry::addRegistrationFunction(OF_CONCAT(registerUnit_, __LINE__));                         \
-            }                                                                                                          \
-        };                                                                                                             \
-                                                                                                                       \
-        static OF_CONCAT(UnitRegistrar_, __LINE__) OF_CONCAT(unitRegistrarInstance_, __LINE__);                        \
+
+#undef REGISTER_UNIT
+#define REGISTER_UNIT(UnitClass) \
+    extern "C" { \
+        OF::UnitRegistry::UnitFactoryFunction \
+        _unit_factory_##UnitClass __attribute__((section(".unit_registry"),used)) = \
+        []() -> std::unique_ptr<OF::Unit> { return std::make_unique<UnitClass>(); }; \
     }
+
 } // namespace OF
 
 #endif // UNITREGISTRY_HPP

--- a/lib/applications/Unit/CMakeLists.txt
+++ b/lib/applications/Unit/CMakeLists.txt
@@ -1,2 +1,3 @@
 zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_UNIT Unit.cpp UnitRegistry.cpp)
+zephyr_linker_sources_ifdef(CONFIG_UNIT DATA_SECTIONS linker/sections.ld)

--- a/lib/applications/Unit/UnitRegistry.cpp
+++ b/lib/applications/Unit/UnitRegistry.cpp
@@ -6,19 +6,16 @@
 
 LOG_MODULE_REGISTER(unit_registry, CONFIG_UNIT_LOG_LEVEL);
 
+extern "C" {
+extern OF::UnitRegistry::UnitFactoryFunction __start_unit_registry[];
+extern OF::UnitRegistry::UnitFactoryFunction __stop_unit_registry[];
+}
+
 namespace OF
 {
     std::vector<UnitRegistry::UnitFactoryFunction> UnitRegistry::g_unitFactories;
     std::vector<UnitRegistry::UnitRegistrationFunction> UnitRegistry::g_registrationFunctions;
     std::unordered_map<std::string_view, std::unique_ptr<Unit>> UnitRegistry::g_units;
-
-    /**
-     * @brief 添加注册函数到注册表
-     */
-    void UnitRegistry::addRegistrationFunction(const UnitRegistrationFunction func)
-    {
-        g_registrationFunctions.push_back(func);
-    }
 
 #ifdef CONFIG_UNIT_THREAD_ANALYZER
     /**
@@ -49,10 +46,9 @@ namespace OF
         g_units.clear();
         g_unitFactories.clear();
 
-        // 执行所有注册函数
-        for (const auto func : g_registrationFunctions)
+        for (auto* it = __start_unit_registry; it != __stop_unit_registry; ++it)
         {
-            func();
+            g_unitFactories.push_back(*it);
         }
 
         for (const auto& factory : g_unitFactories)
@@ -94,6 +90,7 @@ namespace OF
         }
         return std::nullopt;
     }
+
     void UnitRegistry::tryStartUnit(const std::string_view name)
     {
         if (const auto unitOpt = findUnit(name))
@@ -109,6 +106,7 @@ namespace OF
             unitOpt.value()->tryStop();
         }
     }
+
     void UnitRegistry::tryRestartUnit(const std::string_view name)
     {
         if (const auto unitOpt = findUnit(name))

--- a/lib/applications/Unit/UnitRegistry.cpp
+++ b/lib/applications/Unit/UnitRegistry.cpp
@@ -7,8 +7,8 @@
 LOG_MODULE_REGISTER(unit_registry, CONFIG_UNIT_LOG_LEVEL);
 
 extern "C" {
-extern OF::UnitRegistry::UnitFactoryFunction __start_unit_registry[];
-extern OF::UnitRegistry::UnitFactoryFunction __stop_unit_registry[];
+const extern OF::UnitRegistry::UnitFactoryFunction __start_unit_registry[];
+const extern OF::UnitRegistry::UnitFactoryFunction __stop_unit_registry[];
 }
 
 namespace OF

--- a/lib/applications/Unit/linker/sections.ld
+++ b/lib/applications/Unit/linker/sections.ld
@@ -1,0 +1,6 @@
+SECTION_DATA_PROLOGUE(unit_registry,,)
+{
+    __start_unit_registry = .;
+    KEEP(*(SORT_BY_NAME(.unit_registry)));
+    __stop_unit_registry = .;
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
将Unit的工厂函数转移到linker section段中，消除了Unit的静态初始化。